### PR TITLE
Compile into binary and use slim final docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 
 RUN deno compile --allow-net --allow-read --allow-env --output main --target x86_64-unknown-linux-gnu src/main.ts
 
-FROM cgr.dev/chainguard/wolfi-base AS final
+FROM debian:bookworm-slim AS final
 WORKDIR /app
 
 COPY --from=builder /app/main /app/main

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM denoland/deno:2.1.2
-EXPOSE 8080
+FROM denoland/deno:2.1.2 AS builder
+WORKDIR /app
+COPY . .
 
+RUN deno compile --allow-net --allow-read --allow-env --output main --target x86_64-unknown-linux-gnu src/main.ts
+
+FROM cgr.dev/chainguard/wolfi-base AS final
 WORKDIR /app
 
-COPY . .
-RUN touch /app/ca-certificate.crt
+COPY --from=builder /app/main /app/main
+RUN chmod +x /app/main
 
-USER deno
-
-CMD ["task", "start"]
+EXPOSE 8080
+CMD ["/app/main"]

--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,7 @@
     "hono": "jsr:@hono/hono@^4.5.5",
     "drizzle-orm": "npm:drizzle-orm@0.33.0",
     "drizzle-kit": "npm:drizzle-kit@0.24.2",
-    "postgres": "npm:postgres@3.4.4"
+    "postgres": "npm:postgres@3.4.5"
   },
   "tasks": {
     "cache": "deno cache ./src/main.ts ./src/db/schema.ts npm:@libsql/client",

--- a/deno.lock
+++ b/deno.lock
@@ -19,7 +19,7 @@
     "npm:drizzle-kit@0.24.2": "0.24.2_esbuild@0.19.12",
     "npm:drizzle-orm@0.33.0": "0.33.0_@libsql+client@0.14.0",
     "npm:nostr-tools@*": "1.17.0",
-    "npm:postgres@3.4.4": "3.4.4"
+    "npm:postgres@3.4.5": "3.4.5"
   },
   "jsr": {
     "@hono/hono@4.5.5": {
@@ -3502,6 +3502,9 @@
     "postgres@3.4.4": {
       "integrity": "sha512-IbyN+9KslkqcXa8AO9fxpk97PA4pzewvpi2B3Dwy9u4zpV32QicaEdgmF3eSQUzdRk7ttDHQejNgAEr4XoeH4A=="
     },
+    "postgres@3.4.5": {
+      "integrity": "sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg=="
+    },
     "pretty-format@26.6.2": {
       "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
       "dependencies": [
@@ -4472,7 +4475,7 @@
       "jsr:@nostr/tools@^2.10.3",
       "npm:drizzle-kit@0.24.2",
       "npm:drizzle-orm@0.33.0",
-      "npm:postgres@3.4.4"
+      "npm:postgres@3.4.5"
     ]
   }
 }

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -1,7 +1,7 @@
 import { drizzle, PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
-import postgres from "https://deno.land/x/postgresjs@v3.4.5/mod.js";
 import { nwc } from "npm:@getalby/sdk";
+import postgres from "npm:postgres@3.4.5";
 
 import { and, eq } from "drizzle-orm";
 import { DATABASE_URL } from "../constants.ts";
@@ -35,18 +35,19 @@ export class DB {
     if (!parsed.secret) {
       throw new Error("no secret found in connection secret");
     }
-
-    // TODO: use haikunator
+    // TODO: use haikunator    
     username = username || Math.floor(Math.random() * 100000000000).toString();
-
+    
+    const safeNostrPubkey = nostrPubkey || "";
+    
     const encryptedConnectionSecret = await encrypt(connectionSecret);
-
+    
     const [newUser] = await this._db.insert(users).values({
       encryptedConnectionSecret,
       username,
-      nostrPubkey
+      nostrPubkey: safeNostrPubkey
     }).returning({ id: users.id, username: users.username, nostrPubkey: users.nostrPubkey });
-
+    
     return newUser;
   }
 


### PR DESCRIPTION
Compile using deno into binary so that we don't need a deno image to run it and thus container memory usage is smaller.
