### PR TITLE
Add API authentication for /users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ DATABASE_URL=postgresql://myuser:mypass@localhost:5432/alby_lite
 # generate using deno task db:generate:key
 ENCRYPTION_KEY=
 NOSTR_NIP57_PRIVATE_KEY=
+# generate with `openssl rand -hex 32`
+API_KEY=SuperSecretLongRandomString

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A minimal Lightning address server powered by [NWC](https://nwc.dev)
 
 ### Authentication
 
-All API endpoints require authentication using an API key. Set the `API_KEY` environment variable and include it in the `X-API-Key` header with each request.
+Set the `API_KEY` environment variable in your `.env` file to a string of characters of your choice, to protect the `/users` endpoint. Include the API key in an `X-API-Key` header with each request.
+
+If no `API_KEY` is present, it will default to open-access. This means that if the server is exposed to the Internet, anyone can create users in your database, with any name, with funds going to an NWC wallet of their choice.
 
 ### Create a Lightning Address
 

--- a/README.md
+++ b/README.md
@@ -4,21 +4,30 @@ A minimal Lightning address server powered by [NWC](https://nwc.dev)
 
 ## API
 
-### Create a new user
+### Authentication
+
+All API endpoints require authentication using an API key. Set the `API_KEY` environment variable and include it in the `X-API-Key` header with each request.
+
+### Create a Lightning Address
 
 `POST /users`
 
-```json
-{
-  "connectionSecret": "nostr+walletconnect://...",
-  "nostrPubkey": "npubg3tal6y...",
-  "username": "" // optional
-}
+```bash
+curl -X POST https://your-domain.com/users \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-api-key-here" \
+  -d '{
+    "connectionSecret": "nostr+walletconnect://...",
+    "nostrPubkey": "npubg3tal6y...",
+    "username": "" // optional
+  }'
 ```
+
+Note: if a username is not provided, a random one will be generated.
 
 `returns`
 
-```
+```json
 {
     "lightningAddress": "91290133601@albylite.com"
 }
@@ -44,11 +53,12 @@ A minimal Lightning address server powered by [NWC](https://nwc.dev)
 
 ### Configuration Parameters
 
-- LOG_LEVEL: Sets the amount of detail in logs
-- BASE_URL: Base url of the lightning address server
-- DATABASE_URL: Postgres connection string
-- ENCRYPTION_KEY: Secret used to encrypt NWC connection secrets in the DB
-- NOSTR_NIP57_PRIVATE_KEY: private key of zapper service, see [NIP-57](https://github.com/nostr-protocol/nips/blob/master/57.md) for more info
+- `LOG_LEVEL`: Sets the amount of detail in logs
+- `BASE_URL`: Base url of the lightning address server
+- `DATABASE_URL`: Postgres connection string
+- `ENCRYPTION_KEY`: Secret used to encrypt NWC connection secrets in the DB
+- `API_KEY`: Secret key for API authentication (required)
+- `NOSTR_NIP57_PRIVATE_KEY`: private key of zapper service, see [NIP-57](https://github.com/nostr-protocol/nips/blob/master/57.md) for more info
 
 _Environment variables must be setup, including a postgres database connection. Please see .env.example._
 

--- a/src/users.ts
+++ b/src/users.ts
@@ -10,7 +10,30 @@ import { isValid32ByteHex } from "./utils.ts";
 export function createUsersApp(db: DB, nwcPool: NWCPool) {
   const hono = new Hono();
 
+  // Authentication middleware function
+  const checkApiKey = (c: any) => {
+    const apiKey = c.req.header("X-API-Key");
+    const expectedKey = Deno.env.get("API_KEY");
+    
+    if (!expectedKey) {
+      logger.warn("API_KEY not set in environment variables");
+      return true; // Allow if no key is configured (backward compatible)
+    }
+    
+    if (!apiKey || apiKey !== expectedKey) {
+      logger.warn("Unauthorized API access attempt");
+      return false;
+    }
+    
+    return true;
+  };
+
   hono.post("/", async (c) => {
+    // Check authentication
+    if (!checkApiKey(c)) {
+      return c.json({ status: "ERROR", reason: "Unauthorized" }, 401);
+    }
+
     try {
       logger.debug("create user", {});
 
@@ -55,5 +78,6 @@ export function createUsersApp(db: DB, nwcPool: NWCPool) {
       return c.json({ status: "ERROR", reason });
     }
   });
+
   return hono;
 }

--- a/src/users.ts
+++ b/src/users.ts
@@ -16,8 +16,8 @@ export function createUsersApp(db: DB, nwcPool: NWCPool) {
     const expectedKey = Deno.env.get("API_KEY");
     
     if (!expectedKey) {
-      logger.warn("API_KEY not set in environment variables");
-      return true; // Allow if no key is configured (backward compatible)
+      logger.warn("API_KEY environment variable is not set, authorization denied.");
+      return false;
     }
     
     if (!apiKey || apiKey !== expectedKey) {

--- a/src/users.ts
+++ b/src/users.ts
@@ -16,8 +16,8 @@ export function createUsersApp(db: DB, nwcPool: NWCPool) {
     const expectedKey = Deno.env.get("API_KEY");
     
     if (!expectedKey) {
-      logger.warn("API_KEY environment variable is not set, authorization denied.");
-      return false;
+      logger.warn("API_KEY environment variable is not set! ‼️ Anyone with access to the endpoint can create users!");
+      return true;
     }
     
     if (!apiKey || apiKey !== expectedKey) {


### PR DESCRIPTION
Added a simple shared secret authentication to the /users endpoint.

If an environment variable `API_KEY` is present, the incoming request must have an `X-API-Key` header with a matching value, for posts to /users to succeed. If the `API_KEY` environment variable is _not_ set, it defaults to open-access, the condition before this change.

Updated `example.env` and `README.md` with usage examples.

```bash
curl -X POST https://your-domain.com/users \
  -H "Content-Type: application/json" \
  -H "X-API-Key: your-api-key-here" \
  -d '{
    "connectionSecret": "nostr+walletconnect://...",
    "nostrPubkey": "npubg3tal6y...",
    "username": "payme"
  }'
```

### References
* #17 