### PR TITLE
Feature: Add User Delete to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ A minimal Lightning address server powered by [NWC](https://nwc.dev)
 
 `POST /users`
 
-```json
-{
-  "connectionSecret": "nostr+walletconnect://...",
-  "nostrPubkey": "npubg3tal6y...",
-  "username": "" // optional
-}
+```bash
+curl -X POST https://your-domain.com/users \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-api-key-here" \
+  -d '{
+    "connectionSecret": "nostr+walletconnect://...",
+    "nostrPubkey": "npubg3tal6y...",
+    "username": "" // optional
+  }'
 ```
 
 `returns`
@@ -21,6 +24,21 @@ A minimal Lightning address server powered by [NWC](https://nwc.dev)
 ```
 {
     "lightningAddress": "91290133601@albylite.com"
+}
+```
+
+`DELETE /users`
+
+```bash
+curl -s -X DELETE -H "X-API-Key: your-api-key-here" https://your-domain.com/users/USER-TO-DELETE"
+```
+
+`returns`
+
+```json
+{
+  status: "SUCCESS",
+  message: "User USER-TO-DELETE deleted"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,12 @@ A minimal Lightning address server powered by [NWC](https://nwc.dev)
 
 `POST /users`
 
-```bash
-curl -X POST https://your-domain.com/users \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: your-api-key-here" \
-  -d '{
-    "connectionSecret": "nostr+walletconnect://...",
-    "nostrPubkey": "npubg3tal6y...",
-    "username": "" // optional
-  }'
+```json
+{
+  "connectionSecret": "nostr+walletconnect://...",
+  "nostrPubkey": "npubg3tal6y...",
+  "username": "" // optional
+}
 ```
 
 `returns`

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -115,4 +115,13 @@ export class DB {
 
     return;
   }
+
+  async deleteUser(username: string) {
+    const result = await this._db
+      .delete(users)
+      .where(eq(users.username, username))
+      .returning();
+    
+    return result.length > 0;
+  }
 }

--- a/src/users.ts
+++ b/src/users.ts
@@ -15,8 +15,8 @@ export function createUsersApp(db: DB, nwcPool: NWCPool) {
     const expectedKey = Deno.env.get("API_KEY");
     
     if (!expectedKey) {
-      logger.warn("API_KEY environment variable is not set, authorization denied.");
-      return false;
+      logger.warn("API_KEY environment variable is not set! ‼️ Anyone with access to the endpoint can create users!");
+      return true;
     }
     
     if (!apiKey || apiKey !== expectedKey) {
@@ -78,7 +78,9 @@ export function createUsersApp(db: DB, nwcPool: NWCPool) {
   });
 
   hono.delete("/:username", async (c) => {
-    if (!checkApiKey(c)) {
+    const serverAPIKey = Deno.env.get("API_KEY");
+
+    if (!serverAPIKey || !checkApiKey(c)) {
       return c.json({ status: "ERROR", reason: "Unauthorized" }, 401);
     }
 

--- a/src/users.ts
+++ b/src/users.ts
@@ -10,7 +10,28 @@ import { isValid32ByteHex } from "./utils.ts";
 export function createUsersApp(db: DB, nwcPool: NWCPool) {
   const hono = new Hono();
 
+  const checkApiKey = (c: any) => {
+    const apiKey = c.req.header("X-API-Key");
+    const expectedKey = Deno.env.get("API_KEY");
+    
+    if (!expectedKey) {
+      logger.warn("API_KEY environment variable is not set, authorization denied.");
+      return false;
+    }
+    
+    if (!apiKey || apiKey !== expectedKey) {
+      logger.warn("Unauthorized API access attempt");
+      return false;
+    }
+    
+    return true;
+  };
+
   hono.post("/", async (c) => {
+    if (!checkApiKey(c)) {
+      return c.json({ status: "ERROR", reason: "Unauthorized" }, 401);
+    }
+
     try {
       logger.debug("create user", {});
 
@@ -55,5 +76,28 @@ export function createUsersApp(db: DB, nwcPool: NWCPool) {
       return c.json({ status: "ERROR", reason });
     }
   });
+
+  hono.delete("/:username", async (c) => {
+    if (!checkApiKey(c)) {
+      return c.json({ status: "ERROR", reason: "Unauthorized" }, 401);
+    }
+
+    try {
+      const username = c.req.param("username");
+      logger.debug("delete user", { username });
+
+      const result = await db.deleteUser(username);
+
+      if (result) {
+        return c.json({ status: "SUCCESS", message: `User ${username} deleted` });
+      } else {
+        return c.json({ status: "ERROR", reason: "User not found" }, 404);
+      }
+    } catch (error) {
+      logger.error("Failed to delete user", { error, username: c.req.param("username") });
+      return c.json({ status: "ERROR", reason: "Internal server error" }, 500);
+    }
+  });
+ 
   return hono;
 }


### PR DESCRIPTION
- includes `API_KEY` change from https://github.com/getAlby/lite/pull/18
  - allows open access for create user, [as requested](https://github.com/getAlby/lite/pull/18#issuecomment-3540690993), but not for delete users, since that would allow anyone on the Internet to disable your user's NWC wallets
- adds `DELETE` function to remove existing users from the database
- updated README.md

### Example:
```
curl -s -X DELETE -H "X-API-Key: LongApiKeyHere" https://your-domain.com/users/retireduser"
```
